### PR TITLE
Fix command parameter conversion in WPF TicTacToe

### DIFF
--- a/TicTacToe.Wpf/MainViewModel.cs
+++ b/TicTacToe.Wpf/MainViewModel.cs
@@ -34,7 +34,15 @@ public class MainViewModel : INotifyPropertyChanged
 
     public MainViewModel()
     {
-        MakeMoveCommand = new RelayCommand(p => MakeMove((int)p!), p => CanMakeMove((int)p!));
+        MakeMoveCommand = new RelayCommand(
+            p =>
+            {
+                if (TryGetIndex(p, out var index))
+                {
+                    MakeMove(index);
+                }
+            },
+            p => TryGetIndex(p, out var index) && CanMakeMove(index));
         NewGameCommand = new RelayCommand(_ => NewGame());
         ToggleModeCommand = new RelayCommand(_ => ToggleMode());
         UpdateBoard();
@@ -105,6 +113,17 @@ public class MainViewModel : INotifyPropertyChanged
         {
             Status = $"Turn: {_game.CurrentPlayer}";
         }
+    }
+
+    private static bool TryGetIndex(object? parameter, out int index)
+    {
+        if (parameter is null)
+        {
+            index = -1;
+            return false;
+        }
+
+        return int.TryParse(parameter.ToString(), out index);
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;


### PR DESCRIPTION
## Summary
- Safely convert command parameters in `MainViewModel` to avoid invalid casts
- Add `TryGetIndex` helper to validate parameters before executing moves

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d0225bf688332bc1c13c02c13db69