### PR TITLE
Add interactive Tic Tac Toe page for Blazor app

### DIFF
--- a/TicTacToe.Blazor/Pages/TicTacToe.razor
+++ b/TicTacToe.Blazor/Pages/TicTacToe.razor
@@ -1,0 +1,126 @@
+@page "/tic-tac-toe"
+
+<h3>Tic Tac Toe</h3>
+
+<table>
+    @for (var row = 0; row < 3; row++)
+    {
+        <tr>
+            @for (var col = 0; col < 3; col++)
+            {
+                var index = row * 3 + col;
+                <td>
+                    <button @onclick="() => MakeMove(index)" style="width:60px;height:60px;font-size:24px">
+                        @Display(Game.Board[index])
+                    </button>
+                </td>
+            }
+        </tr>
+    }
+</table>
+
+<p>@Status</p>
+<p>Score X:@scoreX O:@scoreO D:@draws</p>
+<p>Mode: @(playVsComputer ? "Vs Computer" : "Vs Human")</p>
+
+<button @onclick="NewGame">New Game</button>
+<button @onclick="() => SetVs(false)">Play vs Human</button>
+<button @onclick="() => SetVs(true)">Play vs Computer</button>
+<button @onclick="ResetScores">Reset Scores</button>
+
+@code {
+    private TicTacToe.Game Game = new();
+    private TicTacToe.RandomBot Bot = new();
+    private bool playVsComputer = true;
+    private int scoreX, scoreO, draws;
+    private string Status = string.Empty;
+
+    protected override void OnInitialized()
+    {
+        UpdateStatus();
+    }
+
+    private void MakeMove(int index)
+    {
+        if (!Game.MakeMove(index)) return;
+        UpdateStatus();
+        if (Game.IsGameOver)
+        {
+            ApplyScore();
+            return;
+        }
+
+        if (playVsComputer && Game.CurrentPlayer == TicTacToe.Cell.O)
+        {
+            var move = Bot.GetMove(Game.Board);
+            if (move >= 0)
+            {
+                Game.MakeMove(move);
+                UpdateStatus();
+                if (Game.IsGameOver)
+                {
+                    ApplyScore();
+                }
+            }
+        }
+    }
+
+    private static string Display(TicTacToe.Cell cell) => cell switch
+    {
+        TicTacToe.Cell.X => "X",
+        TicTacToe.Cell.O => "O",
+        _ => string.Empty
+    };
+
+    private void UpdateStatus()
+    {
+        if (Game.IsGameOver)
+        {
+            Status = Game.Winner switch
+            {
+                TicTacToe.Cell.X => "Winner: X",
+                TicTacToe.Cell.O => "Winner: O",
+                _ => "Draw"
+            };
+        }
+        else
+        {
+            Status = $"Turn: {Game.CurrentPlayer}";
+        }
+    }
+
+    private void ApplyScore()
+    {
+        switch (Game.Winner)
+        {
+            case TicTacToe.Cell.X:
+                scoreX++;
+                break;
+            case TicTacToe.Cell.O:
+                scoreO++;
+                break;
+            default:
+                draws++;
+                break;
+        }
+    }
+
+    private void NewGame()
+    {
+        Game.Reset();
+        UpdateStatus();
+    }
+
+    private void SetVs(bool computer)
+    {
+        playVsComputer = computer;
+        NewGame();
+    }
+
+    private void ResetScores()
+    {
+        scoreX = scoreO = draws = 0;
+        NewGame();
+    }
+}
+

--- a/TicTacToe.Blazor/_Imports.razor
+++ b/TicTacToe.Blazor/_Imports.razor
@@ -6,5 +6,5 @@
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.AspNetCore.Components.WebAssembly.Http
 @using Microsoft.JSInterop
-@using TicTacToe.Blazor
-@using TicTacToe.Blazor.Layout
+@using global::TicTacToe.Blazor
+@using global::TicTacToe.Blazor.Layout


### PR DESCRIPTION
## Summary
- Add new TicTacToe page routed at `/tic-tac-toe`
- Implement 3x3 board, game logic, and RandomBot integration
- Include status display, score tracking, and controls for new games and mode switching
- Resolve namespace conflicts by fully qualifying `TicTacToe` types and updating imports

## Testing
- ❌ `dotnet build TicTacToe.sln` *(command not found: dotnet)*
- ⚠️ `apt-get update` *(403 Forbidden errors installing .NET SDK)*

------
https://chatgpt.com/codex/tasks/task_e_689d32cdc1d483328f1d5e056cd707e3