### PR TITLE
Add win line visualization and victory sound

### DIFF
--- a/TicTacToe.Blazor/Components/Board.razor
+++ b/TicTacToe.Blazor/Components/Board.razor
@@ -30,6 +30,12 @@
             @S.View[i]
         </button>
     }
+    @if (S.WinLine is { } line)
+    {
+        <svg class="win-line" viewBox="0 0 3 3">
+            <line x1="@line.X1" y1="@line.Y1" x2="@line.X2" y2="@line.Y2" />
+        </svg>
+    }
 </div>
 
 @code {

--- a/TicTacToe.Blazor/Services/GameService.cs
+++ b/TicTacToe.Blazor/Services/GameService.cs
@@ -1,4 +1,5 @@
-﻿using TicTacToe; // из твоего Core
+using Microsoft.JSInterop;
+using TicTacToe; // из твоего Core
 
 namespace TicTacToe.Blazor.Services;
 
@@ -6,12 +7,14 @@ public class GameService
 {
     public Game Game { get; } = new();
     private readonly RandomBot _bot = new();
+    private readonly IJSRuntime _js;
 
     public bool PlayVsRandom { get; set; }
     public bool SoundEnabled { get; set; } = true;
 
     public string[] View { get; } = new string[9];
     public bool[] Highlight { get; } = new bool[9];
+    public Line? WinLine { get; private set; }
 
     private int _scoreX, _scoreO, _draws;
 
@@ -24,8 +27,9 @@ public class GameService
     public event Action? Changed;
     private void Notify() => Changed?.Invoke();
 
-    public GameService()
+    public GameService(IJSRuntime js)
     {
+        _js = js;
         UpdateView();
     }
 
@@ -33,6 +37,7 @@ public class GameService
     {
         Game.Reset();
         Array.Fill(Highlight, false);
+        WinLine = null;
         UpdateView();
         Notify();
     }
@@ -108,13 +113,27 @@ public class GameService
         new[] {0,4,8}, new[] {2,4,6}
     };
 
+    private static readonly Line[] WinLines =
+    {
+        new(0.1,0.5,2.9,0.5),
+        new(0.1,1.5,2.9,1.5),
+        new(0.1,2.5,2.9,2.5),
+        new(0.5,0.1,0.5,2.9),
+        new(1.5,0.1,1.5,2.9),
+        new(2.5,0.1,2.5,2.9),
+        new(0.1,0.1,2.9,2.9),
+        new(2.9,0.1,0.1,2.9)
+    };
+
     private void UpdateWinVisuals()
     {
         Array.Fill(Highlight, false);
+        WinLine = null;
         if (!Game.IsGameOver || Game.Winner == Cell.Empty) return;
 
-        foreach (var c in WinCombos)
+        for (int i = 0; i < WinCombos.Length; i++)
         {
+            var c = WinCombos[i];
             var a = c[0]; var b = c[1]; var d = c[2];
             var cellA = Game.Board[a];
             if (cellA != Cell.Empty &&
@@ -122,13 +141,24 @@ public class GameService
                 cellA == Game.Board[d])
             {
                 Highlight[a] = Highlight[b] = Highlight[d] = true;
+                WinLine = WinLines[i];
                 break;
             }
         }
     }
 
-    private static void TryPlayWin()
+    private async void TryPlayWin()
     {
-        // В WASM без JS-аудио оставим пусто (можно добавить IJSRuntime и проигрывать короткий звук)
+        try
+        {
+            await _js.InvokeVoidAsync("eval", "new Audio('win.wav').play()");
+        }
+        catch
+        {
+            // ignore errors in sound playback
+        }
     }
 }
+
+public record struct Line(double X1, double Y1, double X2, double Y2);
+

--- a/TicTacToe.Blazor/wwwroot/app.css
+++ b/TicTacToe.Blazor/wwwroot/app.css
@@ -64,7 +64,8 @@ h1 {
     margin: 0 auto;
     display: grid;
     grid-template-columns: repeat(3,1fr);
-    gap: 12px
+    gap: 12px;
+    position: relative
 }
 
 .cell {
@@ -117,4 +118,28 @@ h1 {
     to {
         transform: scale(1)
     }
+}
+
+.win-line {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none
+}
+
+.win-line line {
+    stroke: var(--accent);
+    stroke-width: .2;
+    stroke-linecap: round
+}
+
+.toggle span::before {
+    content: "\1F50A";
+    margin-right: 4px
+}
+
+.toggle input:not(:checked) + span::before {
+    content: "\1F507";
 }


### PR DESCRIPTION
## Summary
- calculate winning line coordinates and expose them via `GameService`
- render win line SVG over the board and style with CSS
- trigger victory sound using `IJSRuntime`; `win.wav` expected to be added manually

## Testing
- `dotnet build TicTacToe.Blazor/TicTacToe.Blazor.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d66a35e908332ba312a80dab85e18